### PR TITLE
Use eurlatgr as font

### DIFF
--- a/xterm-console
+++ b/xterm-console
@@ -53,7 +53,7 @@ import os
 xx = [
     "xterm",
     # console font
-    "-fn", "lat9w-16",
+    "-fn", "eurlatgr",
     "-fullscreen",
     # no scrollbar
     "+sb",


### PR DESCRIPTION
It's the default since Leap 42.2 and SLE 15.

https://progress.opensuse.org/issues/91341