### PR TITLE
Fix BDF generation for some fonts

### DIFF
--- a/psf2bdf.pl
+++ b/psf2bdf.pl
@@ -69,6 +69,7 @@ for (@ARGV) {
                     $buf =~ m/\G([^\xfe\xff]*+)(?:\xfe[^\xfe\xff]++)*\xff/sg;
                     utf8::decode(my $str = $1);
                     $unicode[$i] = [map ord, split //, $str];
+                    $unilen += (scalar @{$unicode[$i]}) - 1;
                 }
             }
         }

--- a/psf2bdf.pl
+++ b/psf2bdf.pl
@@ -50,7 +50,7 @@ for (@ARGV) {
                         warn 'Unicode sequence ignored' if $u == 0xFFFE;
                     }
                     $unicode[$i] = [@u];
-                    $unilen += (scalar @u) - 1;
+                    $unilen += (scalar @u) - 1 if (scalar @u);
                 }
             }
         }
@@ -69,7 +69,7 @@ for (@ARGV) {
                     $buf =~ m/\G([^\xfe\xff]*+)(?:\xfe[^\xfe\xff]++)*\xff/sg;
                     utf8::decode(my $str = $1);
                     $unicode[$i] = [map ord, split //, $str];
-                    $unilen += (scalar @{$unicode[$i]}) - 1;
+                    $unilen += (scalar @{$unicode[$i]}) - 1 if (scalar @{$unicode[$i]});
                 }
             }
         }


### PR DESCRIPTION
I forgot to adjust `$unilen` in the PSF2 font case.

Apparently some fonts have empty mapping for some glyphs, which wasn't handled gracefully.

This doesn't make any difference to eurlatgr.